### PR TITLE
Prevent paxheaders in release tarball

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -263,7 +263,7 @@ WriteMakefile(
 	      'MYEXTLIB' => $WINDOWS ? ($GNU_WIN ? $ARS_LIBS : '') : $ARS_STATIC_LIB,
 	      'OBJECT' => q[ARS$(OBJ_EXT) support$(OBJ_EXT) supportrev$(OBJ_EXT) supportrev_generated$(OBJ_EXT) ],
 	      'INC'	=> "${INCLUDES}",
-	
+	       macro	=> { TARFLAGS   => "--format=ustar -c -v -f" },
 	      'PM' => $PM,
 
 	      ($] >= 5.005 ?    ## Add these new keywords supported since 5.005


### PR DESCRIPTION
The current dist on cpan contains paxheaders which means it can't be extracted by some tars, for example the one in RHEL 6.

See
 http://cpants.cpanauthors.org/dist/ARSperl-2.00
and
 https://huntingbears.nl/2015/02/17/new-tar-paxheaders-and-installing-from-cpan/
